### PR TITLE
Bug fix: item table refresh, restaurant id persist

### DIFF
--- a/react-social/src/inventory/inventory-form.js
+++ b/react-social/src/inventory/inventory-form.js
@@ -9,15 +9,30 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import TextField from "@material-ui/core/TextField";
-import {API_BASE_URL} from "../constants";
+import { API_BASE_URL } from "../constants";
 import Alert from "react-s-alert";
 import DateFnsUtils from '@date-io/date-fns';
 
+const defaultState = {
+  itemName: "",
+  batchQty: 0,
+  costPerItem: 0,
+  dateBought: new Date(),
+  dateExpired: new Date(),
+  restaurantID: "",
+  itemID: "",
+  batchID: ""
+}
 class InventoryForm extends React.Component {
+
+  setDefaultState () {
+    this.setState(defaultState);
+  }
+
   constructor(props) {
     super(props);
 
-    this.state = { open: false, itemName: "", batchQty: 0, costPerItem: 0, dateBought: new Date(), dateExpired: new Date(), restaurantID: "", itemID: "", batchID: ""}
+    this.state = defaultState;
 
     this.handleChange = this.handleChange.bind(this);
     this.handleOpen = this.handleOpen.bind(this);
@@ -32,11 +47,11 @@ class InventoryForm extends React.Component {
   }
 
   handleClose() {
-    this.setState({open: false});
+    this.setState({ open: false });
   };
 
   handleOpen() {
-    this.setState({open: true});
+    this.setState({ open: true });
   };
 
   handleChange(event) {
@@ -45,55 +60,55 @@ class InventoryForm extends React.Component {
     const inputValue = target.value;
 
     this.setState({
-      [inputName] : inputValue
+      [inputName]: inputValue
     });
   };
 
   handleBoughtDateChange(date) {
-    this.setState({dateBought : date});
+    this.setState({ dateBought: date });
   }
   handleExpDateChange(date) {
-    this.setState({dateExpired : date});
+    this.setState({ dateExpired: date });
   }
-  generateRandomItemID(){
+  generateRandomItemID() {
     var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
     var result = ""
     var chaactersLength = characters.length;
 
-    for ( var i = 0; i < 3 ; i++ ) {
+    for (var i = 0; i < 3; i++) {
       result += characters.charAt(Math.floor(Math.random() * chaactersLength));
     }
-    this.setState({itemID : result.toString()});
+    this.setState({ itemID: result.toString() });
   }
-  generateRandomRestaurantID(){
+  generateRandomRestaurantID() {
     var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
     var result = ""
     var chaactersLength = characters.length;
 
-    for ( var i = 0; i < 3 ; i++ ) {
+    for (var i = 0; i < 3; i++) {
       result += characters.charAt(Math.floor(Math.random() * chaactersLength));
     }
     this.setState({restaurantID : result.toString()});
   }
-  generateRandomBatchID(){
+  generateRandomBatchID() {
     var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
     var result = ""
     var chaactersLength = characters.length;
 
-    for ( var i = 0; i < 3 ; i++ ) {
+    for (var i = 0; i < 3; i++) {
       result += characters.charAt(Math.floor(Math.random() * chaactersLength));
     }
-    this.setState({batchID : result.toString()});
+    this.setState({ batchID: result.toString() });
   }
 
-  handlePreSubmit(event){
+  handlePreSubmit(event) {
     this.generateRandomBatchID();
     this.generateRandomItemID();
     this.generateRandomRestaurantID();
-    if(this.state.batchID == "" && this.state.restaurantID == "" && this.state.itemID == ""){
+    if (this.state.batchID == "" && this.state.restaurantID == "" && this.state.itemID == "") {
       var millisecondsToWait = 500;
-      setTimeout(() =>{
-    // Whatever you want to do after the wait
+      setTimeout(() => {
+        // Whatever you want to do after the wait
         this.handleSubmit(event);
       }, millisecondsToWait);
     }
@@ -108,22 +123,24 @@ class InventoryForm extends React.Component {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        restaurantName : "demo",
-        restaurantID : this.state.restaurantID,
-        itemID : this.state.itemID,
-        itemName : this.state.itemName,
-        batchID : this.state.batchID,
-        batchQty : this.state.batchQty,
-        costPerItem : this.state.costPerItem,
-        dateBought : this.state.dateBought,
-        dateExpired : this.state.dateExpired
+        restaurantName: this.props.currentUser.restaurantName,
+        restaurantID: this.props.currentUser.restaurant_id,
+        itemID: this.state.itemID,
+        itemName: this.state.itemName,
+        batchID: this.state.batchID,
+        batchQty: this.state.batchQty,
+        costPerItem: this.state.costPerItem,
+        dateBought: this.state.dateBought,
+        dateExpired: this.state.dateExpired
       })
     })
       .then(response => {
-        this.setState({open: false});
+        this.setState({ open: false });
+        this.props.onFormSubmit();
+        this.setDefaultState();
       }).catch(error => {
-      Alert.error((error && error.message) || 'Oops! Something went wrong. Please try again!');
-    });
+        Alert.error((error && error.message) || 'Oops! Something went wrong. Please try again!');
+      });
   }
 
   render() {
@@ -134,7 +151,7 @@ class InventoryForm extends React.Component {
           Add New Inventory Item
         </Button>
         <Dialog open={this.state.open} onClose={this.handleClose}
-                aria-labelledby="form-dialog-title">
+          aria-labelledby="form-dialog-title">
           <DialogTitle id="form-dialog-title">Add New Inventory</DialogTitle>
           <DialogContent>
             <TextField
@@ -167,7 +184,7 @@ class InventoryForm extends React.Component {
               type="number"
               fullWidth
             />
-            <br/>
+            <br />
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <KeyboardDatePicker
                 label="Date Bought"
@@ -176,8 +193,8 @@ class InventoryForm extends React.Component {
                 name={"dateBought"}
               />
             </MuiPickersUtilsProvider>
-            <br/>
-            <br/>
+            <br />
+            <br />
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <KeyboardDatePicker
                 label="Date Item(s) will expire"

--- a/react-social/src/inventory/inventory-page.js
+++ b/react-social/src/inventory/inventory-page.js
@@ -3,7 +3,13 @@ import InventoryForm from "./inventory-form";
 import InventoryTable from "./inventory-table";
 import Grid from "@material-ui/core/Grid";
 
-export default function InventoryPage() {
+export default function InventoryPage({currentUser}) {
+
+  const [updateInventory, setUpdateInventory] = React.useState(false);
+  
+  const handleUpdateInventory = () => {
+    setUpdateInventory(!updateInventory);
+  }
 
   return <div>
     <Grid
@@ -15,10 +21,10 @@ export default function InventoryPage() {
       style={{ minHeight: '100vh' }}
     >
       <Grid item xs={3}>
-        <InventoryForm/>
+        <InventoryForm currentUser={currentUser} onFormSubmit={handleUpdateInventory} />
       </Grid>
       <Grid item md={12}>
-        <InventoryTable/>
+        <InventoryTable updateInventory={updateInventory} currentUser={currentUser} />
       </Grid>
     </Grid>
   </div>

--- a/react-social/src/inventory/inventory-table.js
+++ b/react-social/src/inventory/inventory-table.js
@@ -199,7 +199,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function InventoryTable() {
+export default function InventoryTable(props) {
   const classes = useStyles();
   const [rows, setRows] = React.useState([]);
   const [order, setOrder] = React.useState('asc');
@@ -261,9 +261,8 @@ export default function InventoryTable() {
 
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
 
-  useEffect(() => {
-    //get inventory from database
-    fetch(API_BASE_URL + '/getAllInventory', {
+  const fetchInventory = () => {
+    fetch(API_BASE_URL + `/getAllInventory?restaurant_id=${props.currentUser.restaurant_id}`, {
       method: 'Get',
       headers: {
         'Content-Type': 'application/json',
@@ -275,7 +274,17 @@ export default function InventoryTable() {
       }).catch(error => {
       Alert.error((error && error.message) || 'Unable to load inventory');
     });
+  }
+
+  useEffect(() => {
+    //get inventory from database
+    fetchInventory();
   }, []);
+
+  useEffect(() => {
+    //get inventory from database
+    fetchInventory();
+  }, [props.updateInventory]);
 
   return (
     <div className={classes.root}>

--- a/react-social/src/inventory/inventory-table.js
+++ b/react-social/src/inventory/inventory-table.js
@@ -262,6 +262,11 @@ export default function InventoryTable(props) {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
 
   const fetchInventory = () => {
+
+    if(!(props && props.currentUser && props.currentUser.restaurant_id)) {
+      return;
+    }
+
     fetch(API_BASE_URL + `/getAllInventory?restaurant_id=${props.currentUser.restaurant_id}`, {
       method: 'Get',
       headers: {

--- a/react-social/src/menu/menu-form.js
+++ b/react-social/src/menu/menu-form.js
@@ -9,17 +9,26 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import TextField from "@material-ui/core/TextField";
-import {API_BASE_URL} from "../constants";
+import { API_BASE_URL } from "../constants";
 import Alert from "react-s-alert";
 import DateFnsUtils from '@date-io/date-fns';
 
+const defaultState = {
+  open: false,
+  dishName: "",
+  orderQuantity: 0,
+  date: new Date(),
+  orderID: "",
+  restaurantID: "",
+  dishID: ""
+}
 class MenuForm extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = { open: false, dishName: "", orderQuantity: 0, date: new Date(), orderID: "", restaurantID: "", dishID: ""}
+    this.state = defaultState;
 
-    this.handleChange = this.handleChange.bind(this);
+      this.handleChange = this.handleChange.bind(this);
     this.handleOpen = this.handleOpen.bind(this);
     this.handleClose = this.handleClose.bind(this);
     this.handlePreSubmit = this.handlePreSubmit.bind(this);
@@ -31,11 +40,11 @@ class MenuForm extends React.Component {
   }
 
   handleClose() {
-    this.setState({open: false});
+    this.setState({ open: false });
   };
 
   handleOpen() {
-    this.setState({open: true});
+    this.setState({ open: true });
   };
 
   handleChange(event) {
@@ -44,53 +53,53 @@ class MenuForm extends React.Component {
     const inputValue = target.value;
 
     this.setState({
-      [inputName] : inputValue
+      [inputName]: inputValue
     });
   };
 
   handleBoughtDateChange(date) {
-    this.setState({dateBought : date});
+    this.setState({ dateBought: date });
   }
 
-  generateRandomOrderID(){
+  generateRandomOrderID() {
     var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
     var result = ""
     var chaactersLength = characters.length;
 
-    for ( var i = 0; i < 3 ; i++ ) {
+    for (var i = 0; i < 3; i++) {
       result += characters.charAt(Math.floor(Math.random() * chaactersLength));
     }
-    this.setState({orderID : result.toString()});
+    this.setState({ orderID: result.toString() });
   }
-  generateRandomRestaurantID(){
+  generateRandomRestaurantID() {
     var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
     var result = ""
     var chaactersLength = characters.length;
 
-    for ( var i = 0; i < 3 ; i++ ) {
+    for (var i = 0; i < 3; i++) {
       result += characters.charAt(Math.floor(Math.random() * chaactersLength));
     }
-    this.setState({restaurantID : result.toString()});
+    this.setState({ restaurantID: result.toString() });
   }
-  generateRandomDishID(){
+  generateRandomDishID() {
     var characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
     var result = ""
     var chaactersLength = characters.length;
 
-    for ( var i = 0; i < 3 ; i++ ) {
+    for (var i = 0; i < 3; i++) {
       result += characters.charAt(Math.floor(Math.random() * chaactersLength));
     }
-    this.setState({dishID : result.toString()});
+    this.setState({ dishID: result.toString() });
   }
 
-  handlePreSubmit(event){
+  handlePreSubmit(event) {
     this.generateRandomOrderID();
     this.generateRandomRestaurantID();
     this.generateRandomDishID();
-    if(this.state.orderID == "" && this.state.restaurantID == "" && this.state.dishID == ""){
+    if (this.state.orderID == "" && this.state.restaurantID == "" && this.state.dishID == "") {
       var millisecondsToWait = 500;
-      setTimeout(() =>{
-    // Whatever you want to do after the wait
+      setTimeout(() => {
+        // Whatever you want to do after the wait
         this.handleSubmit(event);
       }, millisecondsToWait);
     }
@@ -99,25 +108,27 @@ class MenuForm extends React.Component {
   handleSubmit(event) {
     event.preventDefault();
 
-    fetch(API_BASE_URL + '/addOrder', {
+    fetch(API_BASE_URL + `/addOrder`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        orderId : this.state.orderID,
-        dishId : this.state.dishID,
-        restaurantId : this.state.restaurantID,
-        orderQuantity : this.state.orderQuantity,
-        dishName : this.state.dishName,
-        date : this.state.date
+        orderId: this.state.orderID,
+        dishId: this.state.dishID,
+        restaurantId: this.props.currentUser.restaurant_id,
+        orderQuantity: this.state.orderQuantity,
+        dishName: this.state.dishName,
+        date: this.state.date
       })
     })
       .then(response => {
-        this.setState({open: false});
+        this.setState({ open: false });
+        this.props.onFormSubmit();
+        this.setState(defaultState);
       }).catch(error => {
-      Alert.error((error && error.message) || 'Oops! Something went wrong. Please try again!');
-    });
+        Alert.error((error && error.message) || 'Oops! Something went wrong. Please try again!');
+      });
   }
 
   render() {
@@ -128,7 +139,7 @@ class MenuForm extends React.Component {
           Add New Menu Item
         </Button>
         <Dialog open={this.state.open} onClose={this.handleClose}
-                aria-labelledby="form-dialog-title">
+          aria-labelledby="form-dialog-title">
           <DialogTitle id="form-dialog-title">Add New Menu</DialogTitle>
           <DialogContent>
             <TextField
@@ -151,7 +162,7 @@ class MenuForm extends React.Component {
               type="number"
               fullWidth
             />
-            <br/>
+            <br />
             <MuiPickersUtilsProvider utils={DateFnsUtils}>
               <KeyboardDatePicker
                 label="Date Orderered"
@@ -160,7 +171,7 @@ class MenuForm extends React.Component {
                 name={"dateordered"}
               />
             </MuiPickersUtilsProvider>
-            <br/>
+            <br />
           </DialogContent>
           <DialogActions>
             <Button onClick={this.handleClose} color="primary">

--- a/react-social/src/menu/menu-page.js
+++ b/react-social/src/menu/menu-page.js
@@ -15,8 +15,15 @@ const useStyles = makeStyles({
   },
 });
 
-export default function MenuPage() {
+export default function MenuPage({currentUser}) {
   const classes = useStyles();
+
+  const [updateMenu, setUpdateMenu] = React.useState(false);
+
+  const handleUpdateMenu = () => {
+    console.log("update menu");
+    setUpdateMenu(!updateMenu);
+  };
 
   return <div>
     <Grid
@@ -28,10 +35,10 @@ export default function MenuPage() {
       style={{ minHeight: '100vh' }}
     >
       <Grid item xs={3}>
-        <MenuForm/>
+        <MenuForm onFormSubmit={handleUpdateMenu} currentUser={currentUser} />
       </Grid>
       <Grid item md={12}>
-        <MenuTable/>
+        <MenuTable updateMenu={updateMenu} currentUser={currentUser} />
       </Grid>
     </Grid>
 </div>

--- a/react-social/src/menu/menu-table.js
+++ b/react-social/src/menu/menu-table.js
@@ -197,7 +197,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function MenuTable() {
+export default function MenuTable(props) {
   const classes = useStyles();
   const [rows, setRows] = React.useState([]);
   const [order, setOrder] = React.useState('asc');
@@ -259,9 +259,8 @@ export default function MenuTable() {
 
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
 
-  useEffect(() => {
-    //get inventory from database
-    fetch(API_BASE_URL + '/getAllOrders', {
+  const fetchAllOrders = () => {
+    fetch(API_BASE_URL + `/getAllOrders?restaurant_id=${props.currentUser.restaurant_id}`, {
       method: 'Get',
       headers: {
         'Content-Type': 'application/json',
@@ -273,7 +272,17 @@ export default function MenuTable() {
       }).catch(error => {
       Alert.error((error && error.message) || 'Unable to load menu');
     });
+  }
+
+  useEffect(() => {
+    //get inventory from database
+    fetchAllOrders();
   }, []);
+  
+  useEffect(() => {
+    fetchAllOrders();
+    console.log("fetching all orders again");
+  }, [props.updateMenu]);
 
   return (
     <div className={classes.root}>
@@ -305,11 +314,11 @@ export default function MenuTable() {
                   return (
                     <TableRow
                       hover
+                      key={row.dishId}
                       onClick={(event) => handleClick(event, row.dishName)}
                       role="checkbox"
                       aria-checked={isItemSelected}
                       tabIndex={-1}
-                      key={row.dishName}
                       selected={isItemSelected}
                     >
                       <TableCell padding="checkbox">

--- a/react-social/src/menu/menu-table.js
+++ b/react-social/src/menu/menu-table.js
@@ -260,6 +260,11 @@ export default function MenuTable(props) {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
 
   const fetchAllOrders = () => {
+
+    if(!(props && props.currentUser && props.currentUser.restaurant_id)) {
+      return;
+    }
+
     fetch(API_BASE_URL + `/getAllOrders?restaurant_id=${props.currentUser.restaurant_id}`, {
       method: 'Get',
       headers: {

--- a/react-social/src/notifications/notifications-page.js
+++ b/react-social/src/notifications/notifications-page.js
@@ -42,14 +42,14 @@ export default function NotificationsPage({ currentUser }) {
       return;
     }
     fetchExpiredInventoryItems({
-      "restaurant_name": currentUser.restaurantName,
+      "restaurant_id": currentUser.restaurant_id,
     }).then((response) => {
       // console.log(response);
       setExpiredItems(response);
     });
 
     fetchAboutToExpireInventoryItems({
-      "restaurant_name": currentUser.restaurantName,
+      "restaurant_id": currentUser.restaurant_id,
       "expires_in_days": NOTIFICATION_EXPIRY_DAYS,
     }).then((response) => {
       // console.log(response);
@@ -57,7 +57,7 @@ export default function NotificationsPage({ currentUser }) {
     });
 
     fetchLowQuantityInventoryItems({
-      "restaurant_name": currentUser.restaurantName,
+      "restaurant_id": currentUser.restaurant_id,
       "max_qty": NOTIFICATION_LOW_QUANTITY_THRESHOLD,
     }).then((response) => {
       // console.log(response);

--- a/spring-social/create_table.sql
+++ b/spring-social/create_table.sql
@@ -5,6 +5,7 @@ CREATE TABLE `users` (
   `id` int NOT NULL AUTO_INCREMENT,
   `email` varchar(45) NOT NULL,
   `restaurantName` varchar(45) NOT NULL DEFAULT 'CSC510',
+  `restaurant_id` varchar(45) NOT NULL DEFAULT (uuid()),
   `name` varchar(45) NOT NULL,
   `role` varchar(45) NOT NULL,
   `password` varchar(255),

--- a/spring-social/src/main/java/com/example/springsocial/controller/AuthController.java
+++ b/spring-social/src/main/java/com/example/springsocial/controller/AuthController.java
@@ -28,6 +28,7 @@ import javax.annotation.PostConstruct;
 import javax.validation.Valid;
 import java.net.URI;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
@@ -116,6 +117,8 @@ public class AuthController {
         user.setRestaurantName(signUpRequest.getRestaurantName());
         user.setRole(signUpRequest.getRole());
         user.setPassword(passwordEncoder.encode(user.getPassword()));
+        user.setRestaurant_id(UUID.randomUUID().toString());
+
         User result = userRepository.save(user);
 
         URI location = ServletUriComponentsBuilder

--- a/spring-social/src/main/java/com/example/springsocial/controller/InventoryController.java
+++ b/spring-social/src/main/java/com/example/springsocial/controller/InventoryController.java
@@ -58,9 +58,9 @@ public class InventoryController {
     /**
     * This method is used to call all the items in the inventory.
     */
-    public String getAllInventory(){
+    public String getAllInventory(@RequestParam String restaurant_id){
 
-        List<Inventory> inventory =  inventoryRepository.findAll();
+        List<Inventory> inventory =  inventoryRepository.findInventoryByRestaurantID(restaurant_id);
         String inventoryJson = new Gson().toJson(inventory);
         return inventoryJson;
 

--- a/spring-social/src/main/java/com/example/springsocial/controller/NotificationController.java
+++ b/spring-social/src/main/java/com/example/springsocial/controller/NotificationController.java
@@ -39,7 +39,7 @@ public class NotificationController {
 
     @PostMapping("/findExpiredInventory")
     public String fetchExpiredInventoryItems(@Valid @RequestBody NotificationExpiredRequest notificationExpiredRequest) {
-        List<Inventory> expiredInventoryItems = inventoryRepository.findInventoryByRestaurantNameAndDateExpiredLessThan(notificationExpiredRequest.restaurant_name, new Date());
+        List<Inventory> expiredInventoryItems = inventoryRepository.findInventoryByRestaurantIDAndDateExpiredLessThan(notificationExpiredRequest.restaurant_id, new Date());
 
         String inventoryItemsExpired = new Gson().toJson(expiredInventoryItems);
 
@@ -56,7 +56,7 @@ public class NotificationController {
 
         logger.info("After date: " + dateAfterNDays.toString());
 
-        List<Inventory> aboutToExpireInventoryItems = inventoryRepository.findInventoryByRestaurantNameAndDateExpiredBetween(notificationAboutToExpireRequest.restaurant_name, new Date(), dateAfterNDays);
+        List<Inventory> aboutToExpireInventoryItems = inventoryRepository.findInventoryByRestaurantIDAndDateExpiredBetween(notificationAboutToExpireRequest.restaurant_id, new Date(), dateAfterNDays);
 
         String aboutToExpireInventoryItemsJSON = new Gson().toJson(aboutToExpireInventoryItems);
 
@@ -67,7 +67,7 @@ public class NotificationController {
     @PostMapping("/findLowQuantityInventoryItems")
     public String fetchLowQuantityInventoryItems(@Valid @RequestBody LowInventoryRequest lowInventoryRequest) {
 
-        List<Inventory> lowQuantityItems = inventoryRepository.findInventoryByRestaurantNameAndBatchQtyLessThanEqual(lowInventoryRequest.restaurant_name, lowInventoryRequest.max_qty);
+        List<Inventory> lowQuantityItems = inventoryRepository.findInventoryByRestaurantIDAndBatchQtyLessThanEqual(lowInventoryRequest.restaurant_id, lowInventoryRequest.max_qty);
 
         String lowQuantityItemsJson = new Gson().toJson(lowQuantityItems);
 

--- a/spring-social/src/main/java/com/example/springsocial/controller/NotificationController.java
+++ b/spring-social/src/main/java/com/example/springsocial/controller/NotificationController.java
@@ -25,18 +25,12 @@ public class NotificationController {
     @Autowired
     private InventoryRepository inventoryRepository;
 
-    @GetMapping("/fetch-notifications")
-    public String fetchNotifications(@RequestParam("restaurant_id") String restaurant_id) {
 
-        // Fetch all inventory items that are about to expire
-
-        List<Inventory> inventoryItems = inventoryRepository.findInventoryByRestaurantID(restaurant_id);
-
-        String inventoryJson = new Gson().toJson(inventoryItems);
-
-        return inventoryJson;
-    }
-
+    /**
+     * API used to fetch inventory items that have expired for a particular restaurant
+     * @param notificationExpiredRequest
+     * @return JSON object with list of inventory items that have expired
+     */
     @PostMapping("/findExpiredInventory")
     public String fetchExpiredInventoryItems(@Valid @RequestBody NotificationExpiredRequest notificationExpiredRequest) {
         List<Inventory> expiredInventoryItems = inventoryRepository.findInventoryByRestaurantIDAndDateExpiredLessThan(notificationExpiredRequest.restaurant_id, new Date());
@@ -47,6 +41,11 @@ public class NotificationController {
 
     }
 
+    /**
+     * API used to fetch inventory items that are about to expire in the next N days
+     * @param notificationAboutToExpireRequest
+     * @return JSON object with list of inventory items that are about to expire
+     */
     @PostMapping("/findAboutToExpireInventory")
     public String fetchExpiredInventoryItems(@Valid @RequestBody NotificationAboutToExpireRequest notificationAboutToExpireRequest) {
 
@@ -64,6 +63,11 @@ public class NotificationController {
 
     }
 
+    /**
+     * API used to fetch inventory items that have quantity less than N left
+     * @param lowInventoryRequest
+     * @return JSON object with list of inventory items that have low quantity
+     */
     @PostMapping("/findLowQuantityInventoryItems")
     public String fetchLowQuantityInventoryItems(@Valid @RequestBody LowInventoryRequest lowInventoryRequest) {
 

--- a/spring-social/src/main/java/com/example/springsocial/controller/OrderController.java
+++ b/spring-social/src/main/java/com/example/springsocial/controller/OrderController.java
@@ -7,10 +7,7 @@ import com.google.gson.Gson;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.PostConstruct;
 import javax.validation.Valid;
@@ -69,9 +66,9 @@ public class OrderController {
     /**
      * This method is used to call all the orders in the inventory.
      */
-    public String getAllOrders(){
+    public String getAllOrders(@RequestParam String restaurant_id){
 
-        List<Order> order =  orderRepository.findAll();
+        List<Order> order =  orderRepository.findOrderByRestaurantId(restaurant_id);
         String orderJson = new Gson().toJson(order);
         logger.info("successfully fetched all the order");
         return orderJson;

--- a/spring-social/src/main/java/com/example/springsocial/model/User.java
+++ b/spring-social/src/main/java/com/example/springsocial/model/User.java
@@ -17,6 +17,8 @@ public class User {
     @Column(nullable = false)
     private String restaurantName;
 
+    private String restaurant_id;
+
     @Column(nullable = false)
     private String name;
 
@@ -117,5 +119,13 @@ public class User {
 
     public void setProvider(String provider) {
         this.provider = provider;
+    }
+
+    public String getRestaurant_id() {
+        return restaurant_id;
+    }
+
+    public void setRestaurant_id(String restaurant_id) {
+        this.restaurant_id = restaurant_id;
     }
 }

--- a/spring-social/src/main/java/com/example/springsocial/payload/LowInventoryRequest.java
+++ b/spring-social/src/main/java/com/example/springsocial/payload/LowInventoryRequest.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 public class LowInventoryRequest {
 
     @NotBlank
-    public String restaurant_name;
+    public String restaurant_id;
 
     @NotNull
     @Min(1)

--- a/spring-social/src/main/java/com/example/springsocial/payload/NotificationAboutToExpireRequest.java
+++ b/spring-social/src/main/java/com/example/springsocial/payload/NotificationAboutToExpireRequest.java
@@ -6,7 +6,7 @@ import java.util.Date;
 
 public class NotificationAboutToExpireRequest {
     @NotBlank
-    public String restaurant_name;
+    public String restaurant_id;
 
     @NotNull
     public int expires_in_days;

--- a/spring-social/src/main/java/com/example/springsocial/payload/NotificationExpiredRequest.java
+++ b/spring-social/src/main/java/com/example/springsocial/payload/NotificationExpiredRequest.java
@@ -5,6 +5,6 @@ import javax.validation.constraints.NotBlank;
 public class NotificationExpiredRequest {
 
     @NotBlank
-    public String restaurant_name;
+    public String restaurant_id;
 
 }

--- a/spring-social/src/main/java/com/example/springsocial/repository/InventoryRepository.java
+++ b/spring-social/src/main/java/com/example/springsocial/repository/InventoryRepository.java
@@ -20,11 +20,11 @@ public interface InventoryRepository extends JpaRepository<Inventory, String> {
 
     List<Inventory> findInventoryByRestaurantID(String restaurantId);
 
-    List<Inventory> findInventoryByRestaurantNameAndDateExpiredBetween(String restaurant_name, Date expiredStart, Date expiredEnd);
+    List<Inventory> findInventoryByRestaurantIDAndDateExpiredBetween(String restaurant_id, Date expiredStart, Date expiredEnd);
 
-    List<Inventory> findInventoryByRestaurantNameAndDateExpiredLessThan(String restaurant_name, Date expiredDate);
+    List<Inventory> findInventoryByRestaurantIDAndDateExpiredLessThan(String restaurant_id, Date expiredDate);
 
-    List<Inventory> findInventoryByRestaurantNameAndBatchQtyLessThanEqual(String restaurant_name, int maxQuantity);
+    List<Inventory> findInventoryByRestaurantIDAndBatchQtyLessThanEqual(String restaurant_id, int maxQuantity);
 
 }//    Optional<Inventory> findByRestaurant(String restaurantID);
 

--- a/spring-social/src/main/java/com/example/springsocial/repository/OrderRepository.java
+++ b/spring-social/src/main/java/com/example/springsocial/repository/OrderRepository.java
@@ -20,5 +20,5 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 //    public ResponseEntity<?> addOrder(@Valid, @RequestBody OrderRequest orderRequest)
     List<Order> findAll();
 
-
+    List<Order> findOrderByRestaurantId(String restaurant_id);
 }

--- a/spring-social/src/main/java/com/example/springsocial/security/oauth2/CustomOAuth2UserService.java
+++ b/spring-social/src/main/java/com/example/springsocial/security/oauth2/CustomOAuth2UserService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
@@ -71,6 +72,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         user.setEmail(oAuth2UserInfo.getEmail());
         user.setImageUrl(oAuth2UserInfo.getImageUrl());
         user.setRestaurantName("CSC510");
+        user.setRestaurant_id(UUID.randomUUID().toString());
         user.setRole("default_role");
         return userRepository.save(user);
     }

--- a/spring-social/src/test/java/com/example/springsocial/controller/InventoryControllerTests.java
+++ b/spring-social/src/test/java/com/example/springsocial/controller/InventoryControllerTests.java
@@ -69,7 +69,7 @@ public class InventoryControllerTests {
 
     @Test
     void whenValidInput_thenReturns200() throws Exception {
-        String uri = "/getAllInventory";
+        String uri = "/getAllInventory?restaurant_id=r01";
 
         MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.get(uri)
                 .accept(MediaType.APPLICATION_JSON_VALUE)).andReturn();

--- a/spring-social/src/test/java/com/example/springsocial/controller/OrderControllerTests.java
+++ b/spring-social/src/test/java/com/example/springsocial/controller/OrderControllerTests.java
@@ -81,7 +81,7 @@ public class OrderControllerTests {
 
     @Test
     void whenValidInput_thenReturns200() throws Exception {
-        String uri = "/getAllOrders";
+        String uri = "/getAllOrders?restaurant_id=r10";
         order = new Order();
         order.setOrderId("o10");
         order.setRestaurantId("r10");


### PR DESCRIPTION
This PR addresses the following issues

- Refresh inventory and menu page on add item
- Filter inventory and menu items by restaurant_id
- add restaurant_id field to user and persist across item addition calls
- Assign default value to restaurant_id as randomly generated uuid